### PR TITLE
ジャックポットルーレット機能の実装

### DIFF
--- a/src/main/java/com/kamesuta/physxmc/PhysxMc.java
+++ b/src/main/java/com/kamesuta/physxmc/PhysxMc.java
@@ -16,6 +16,7 @@ import com.kamesuta.physxmc.utils.ConversionUtility;
 import com.kamesuta.physxmc.utils.PhysxLoader;
 import com.kamesuta.physxmc.widget.EventHandler;
 import com.kamesuta.physxmc.widget.GrabTool;
+import com.kamesuta.physxmc.widget.JackpotRouletteManager;
 import com.kamesuta.physxmc.widget.PlayerTriggerHolder;
 import com.kamesuta.physxmc.widget.PhysicsObjectManager;
 import com.kamesuta.physxmc.widget.PusherManager;
@@ -46,6 +47,7 @@ public final class PhysxMc extends JavaPlugin {
     public static PusherManager pusherManager;
     public static PhysicsObjectManager physicsObjectManager;
     public static RampManager rampManager;
+    public static JackpotRouletteManager jackpotRouletteManager;
 
     public static GrabTool grabTool;
     public ProtocolManager protocolManager;
@@ -74,6 +76,7 @@ public final class PhysxMc extends JavaPlugin {
         pusherManager = new PusherManager(getDataFolder());
         physicsObjectManager = new PhysicsObjectManager(getDataFolder());
         rampManager = new RampManager();
+        jackpotRouletteManager = new JackpotRouletteManager();
         grabTool = new GrabTool();
         
         // データを読み込み（1秒後に実行してワールドが完全に読み込まれてから）
@@ -102,6 +105,7 @@ public final class PhysxMc extends JavaPlugin {
                 playerTriggerHolder.update();
                 pusherManager.update();
                 rampManager.update();
+                jackpotRouletteManager.update();
                 grabTool.update();
                 
                 // 自動保存処理（5分間隔）
@@ -217,6 +221,10 @@ public final class PhysxMc extends JavaPlugin {
 
         if (rampManager != null) {
             rampManager.destroyAll();
+        }
+        
+        if (jackpotRouletteManager != null) {
+            jackpotRouletteManager.destroyAll();
         }
 
         // 最後にPhysXを終了

--- a/src/main/java/com/kamesuta/physxmc/command/PhysxCommand.java
+++ b/src/main/java/com/kamesuta/physxmc/command/PhysxCommand.java
@@ -3,6 +3,7 @@ package com.kamesuta.physxmc.command;
 import com.destroystokyo.paper.event.server.AsyncTabCompleteEvent;
 import com.kamesuta.physxmc.PhysxMc;
 import com.kamesuta.physxmc.PhysxSetting;
+import com.kamesuta.physxmc.widget.JackpotRoulette;
 import com.kamesuta.physxmc.widget.MedalPusher;
 import net.kyori.adventure.text.Component;
 import org.bukkit.Material;
@@ -282,6 +283,67 @@ public class PhysxCommand extends CommandBase implements Listener {
                 return true;
             }
         }
+        
+        // ジャックポットルーレットコマンド
+        if (arguments[0].equals("jackpot")) {
+            if (!(sender instanceof Player)) {
+                sender.sendMessage("プレイヤーしか実行できません");
+                return true;
+            }
+            Player player = (Player) sender;
+            
+            if (arguments.length < 2) {
+                sender.sendMessage("使用法: /physxmc jackpot <create|launch|remove|clear|count|info>");
+                return true;
+            }
+            
+            if (arguments[1].equals("create")) {
+                // デフォルト設定でジャックポットルーレットを作成
+                if (PhysxMc.jackpotRouletteManager.createDefaultRoulette(player.getLocation()) != null) {
+                    sender.sendMessage("ジャックポットルーレットを作成しました！");
+                } else {
+                    sender.sendMessage("ルーレットの作成に失敗しました。近くに既存のルーレットがないか確認してください。");
+                }
+                return true;
+            } else if (arguments[1].equals("launch")) {
+                // ボールを投入
+                if (PhysxMc.jackpotRouletteManager.launchBall(player, player.getLocation())) {
+                    // 成功メッセージはlaunchBall内で表示される
+                } else {
+                    // エラーメッセージはlaunchBall内で表示される
+                }
+                return true;
+            } else if (arguments[1].equals("remove")) {
+                // 近くのルーレットを削除
+                if (PhysxMc.jackpotRouletteManager.removeNearestRoulette(player.getLocation(), 15.0)) {
+                    sender.sendMessage("近くのジャックポットルーレットを削除しました");
+                } else {
+                    sender.sendMessage("近くにジャックポットルーレットが見つかりません");
+                }
+                return true;
+            } else if (arguments[1].equals("clear")) {
+                // 全てのルーレットを削除
+                PhysxMc.jackpotRouletteManager.destroyAll();
+                sender.sendMessage("全てのジャックポットルーレットを削除しました");
+                return true;
+            } else if (arguments[1].equals("count")) {
+                // ルーレット数を表示
+                int rouletteCount = PhysxMc.jackpotRouletteManager.getRouletteCount();
+                int ballCount = PhysxMc.jackpotRouletteManager.getTrackingBallCount();
+                sender.sendMessage("現在のジャックポットルーレット数: " + rouletteCount);
+                sender.sendMessage("追跡中のボール数: " + ballCount);
+                return true;
+            } else if (arguments[1].equals("info")) {
+                // 最寄りのルーレット情報を表示
+                JackpotRoulette nearest = PhysxMc.jackpotRouletteManager.findNearestRoulette(player.getLocation(), 15.0);
+                if (nearest != null) {
+                    sender.sendMessage(nearest.getSlotInfo());
+                } else {
+                    sender.sendMessage("近くにジャックポットルーレットがありません");
+                }
+                return true;
+            }
+        }
 
         sendUsage(sender);
         return true;
@@ -304,7 +366,13 @@ public class PhysxCommand extends CommandBase implements Listener {
                 "/physxmc ramp create {角度} {幅} {長さ} {厚み} [ブロック名]: 傾斜板を作成する\n" +
                 "/physxmc ramp remove: 近くのランプを削除する\n" +
                 "/physxmc ramp clear: 全てのランプを削除する\n" +
-                "/physxmc ramp count: ランプの数を表示する\n"));
+                "/physxmc ramp count: ランプの数を表示する\n" +
+                "/physxmc jackpot create: ジャックポットルーレットを作成する\n" +
+                "/physxmc jackpot launch: ボールを投入してゲーム開始\n" +
+                "/physxmc jackpot remove: 近くのルーレットを削除する\n" +
+                "/physxmc jackpot clear: 全てのルーレットを削除する\n" +
+                "/physxmc jackpot count: ルーレット数と追跡中ボール数を表示する\n" +
+                "/physxmc jackpot info: 近くのルーレット詳細情報を表示する\n"));
     }
 
     @EventHandler

--- a/src/main/java/com/kamesuta/physxmc/widget/JackpotRoulette.java
+++ b/src/main/java/com/kamesuta/physxmc/widget/JackpotRoulette.java
@@ -1,0 +1,248 @@
+package com.kamesuta.physxmc.widget;
+
+import com.kamesuta.physxmc.PhysxMc;
+import com.kamesuta.physxmc.wrapper.DisplayedPhysxBox;
+import com.kamesuta.physxmc.wrapper.DisplayedPhysxSphere;
+import lombok.Getter;
+import org.bukkit.Location;
+import org.bukkit.Material;
+import org.bukkit.entity.Player;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.util.Vector;
+import org.joml.Quaternionf;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.logging.Logger;
+
+/**
+ * ジャックポットチャンス機能
+ * 回転する円盤でボールを転がして穴に落とす物理抽選システム
+ */
+public class JackpotRoulette {
+    
+    private final Location centerLocation;
+    private final double radius;
+    private final double rotationSpeed;
+    private final Material diskMaterial;
+    private final Material winSlotMaterial;
+    private final Material normalSlotMaterial;
+    
+    @Getter
+    private DisplayedPhysxBox rotatingDisk; // 回転する円盤
+    private final List<RouletteSlot> slots = new ArrayList<>(); // 穴（スロット）
+    
+    private double currentRotation = 0.0; // 現在の回転角度
+    private final Logger logger;
+    
+    // 設定値
+    private static final int SLOT_COUNT = 5; // 穴の数
+    private static final double DISK_THICKNESS = 0.2; // 円盤の厚さ
+    private static final double SLOT_DEPTH = 1.0; // 穴の深さ
+    private static final double SLOT_WIDTH = 1.5; // 穴の幅
+    
+    /**
+     * ジャックポットルーレットを作成
+     * @param centerLocation 中心位置
+     * @param radius 円盤の半径
+     * @param rotationSpeed 回転速度（ラジアン/tick）
+     * @param diskMaterial 円盤の材質
+     * @param winSlotMaterial 当たり穴の材質
+     * @param normalSlotMaterial 通常穴の材質
+     */
+    public JackpotRoulette(Location centerLocation, double radius, double rotationSpeed, 
+                          Material diskMaterial, Material winSlotMaterial, Material normalSlotMaterial) {
+        this.centerLocation = centerLocation.clone();
+        this.radius = radius;
+        this.rotationSpeed = rotationSpeed;
+        this.diskMaterial = diskMaterial;
+        this.winSlotMaterial = winSlotMaterial;
+        this.normalSlotMaterial = normalSlotMaterial;
+        this.logger = PhysxMc.getPlugin(PhysxMc.class).getLogger();
+        
+        createRoulette();
+    }
+    
+    /**
+     * ルーレット全体を作成
+     */
+    private void createRoulette() {
+        createRotatingDisk();
+        createSlots();
+        logger.info("ジャックポットルーレットを作成: 半径" + radius + ", 穴" + SLOT_COUNT + "個");
+    }
+    
+    /**
+     * 回転する円盤を作成
+     */
+    private void createRotatingDisk() {
+        Vector diskSize = new Vector(radius * 2, DISK_THICKNESS, radius * 2);
+        ItemStack diskItem = new ItemStack(diskMaterial);
+        List<Vector> offsets = List.of(new Vector()); // 単一のディスプレイ
+        
+        rotatingDisk = PhysxMc.displayedBoxHolder.createDisplayedBox(
+            centerLocation.clone(),
+            diskSize,
+            diskItem,
+            offsets,
+            500.0f, // 重い密度で安定性確保
+            false   // プッシャーではない
+        );
+        
+        if (rotatingDisk != null) {
+            rotatingDisk.makeKinematic(true); // キネマティック制御で回転
+            logger.info("回転円盤を作成: サイズ " + diskSize);
+        } else {
+            logger.warning("回転円盤の作成に失敗しました");
+        }
+    }
+    
+    /**
+     * 穴（スロット）を作成
+     */
+    private void createSlots() {
+        for (int i = 0; i < SLOT_COUNT; i++) {
+            double angle = (2 * Math.PI * i) / SLOT_COUNT; // 等間隔で配置
+            boolean isWinSlot = (i == 0); // 最初の穴を当たり穴に設定
+            
+            // 穴の位置を計算（円盤の外周）
+            double slotX = centerLocation.getX() + Math.cos(angle) * (radius + SLOT_WIDTH / 2);
+            double slotZ = centerLocation.getZ() + Math.sin(angle) * (radius + SLOT_WIDTH / 2);
+            double slotY = centerLocation.getY() - SLOT_DEPTH / 2; // 少し下に配置
+            
+            Location slotLocation = new Location(centerLocation.getWorld(), slotX, slotY, slotZ);
+            Material slotMaterial = isWinSlot ? winSlotMaterial : normalSlotMaterial;
+            
+            RouletteSlot slot = new RouletteSlot(i, slotLocation, slotMaterial, isWinSlot, angle);
+            slots.add(slot);
+            
+            logger.info("スロット" + i + "を作成: " + (isWinSlot ? "当たり" : "通常") + " at " + 
+                       String.format("%.1f,%.1f,%.1f", slotX, slotY, slotZ));
+        }
+    }
+    
+    /**
+     * 毎tick更新処理
+     */
+    public void update() {
+        if (rotatingDisk != null && !rotatingDisk.isDisplayDead()) {
+            // 円盤を回転
+            currentRotation += rotationSpeed;
+            if (currentRotation >= 2 * Math.PI) {
+                currentRotation -= 2 * Math.PI; // 2πで正規化
+            }
+            
+            // Y軸周りの回転を適用
+            Quaternionf rotation = new Quaternionf().rotateY((float) currentRotation);
+            rotatingDisk.moveKinematic(new Vector(centerLocation.getX(), centerLocation.getY(), centerLocation.getZ()), rotation);
+        }
+        
+        // スロットの更新
+        for (RouletteSlot slot : slots) {
+            slot.update();
+        }
+    }
+    
+    /**
+     * ボールを投入
+     * @param player 投入したプレイヤー
+     * @return 投入されたボールのオブジェクト
+     */
+    public DisplayedPhysxSphere launchBall(Player player) {
+        // 中央より少し上の位置からボールを投入
+        Location ballLocation = centerLocation.clone().add(0, 2, 0);
+        
+        // ボールを作成（適度な大きさと重さ）
+        DisplayedPhysxSphere ball = PhysxMc.displayedSphereHolder.createDisplayedSphere(
+            ballLocation,
+            0.3, // 半径
+            Material.GOLD_BLOCK, // 金色のボール
+            3.0f // 密度
+        );
+        
+        if (ball != null) {
+            // 少しランダムな初期速度を与える
+            double randomX = (Math.random() - 0.5) * 2.0;
+            double randomZ = (Math.random() - 0.5) * 2.0;
+            Vector initialVelocity = new Vector(randomX, -1.0, randomZ);
+            
+            // ボールに初期速度を適用
+            if (ball.getActor() != null) {
+                physx.common.PxVec3 velocity = new physx.common.PxVec3((float) initialVelocity.getX(), 
+                                                                       (float) initialVelocity.getY(), 
+                                                                       (float) initialVelocity.getZ());
+                ball.getActor().setLinearVelocity(velocity);
+                velocity.destroy();
+            }
+            
+            logger.info(player.getName() + "がジャックポットボールを投入しました");
+        } else {
+            logger.warning("ボールの作成に失敗しました");
+        }
+        
+        return ball;
+    }
+    
+    /**
+     * ボールがスロットに落ちたかチェック
+     * @param ballLocation ボールの位置
+     * @return 落ちたスロット、なければnull
+     */
+    public RouletteSlot checkBallInSlot(Location ballLocation) {
+        for (RouletteSlot slot : slots) {
+            if (slot.isLocationInSlot(ballLocation)) {
+                return slot;
+            }
+        }
+        return null;
+    }
+    
+    /**
+     * ルーレットが有効かどうか
+     */
+    public boolean isValid() {
+        return rotatingDisk != null && !rotatingDisk.isDisplayDead() && !slots.isEmpty();
+    }
+    
+    /**
+     * ルーレットを破壊
+     */
+    public void destroy() {
+        if (rotatingDisk != null) {
+            PhysxMc.displayedBoxHolder.destroySpecific(rotatingDisk);
+            rotatingDisk = null;
+        }
+        
+        for (RouletteSlot slot : slots) {
+            slot.destroy();
+        }
+        slots.clear();
+        
+        logger.info("ジャックポットルーレットを破壊しました");
+    }
+    
+    /**
+     * 中心位置を取得
+     */
+    public Location getCenterLocation() {
+        return centerLocation.clone();
+    }
+    
+    /**
+     * 穴の詳細情報を取得
+     */
+    public String getSlotInfo() {
+        StringBuilder info = new StringBuilder();
+        info.append("ジャックポットルーレット情報:\n");
+        info.append("- 半径: ").append(radius).append("\n");
+        info.append("- 回転速度: ").append(String.format("%.3f", rotationSpeed)).append(" rad/tick\n");
+        info.append("- 穴の数: ").append(slots.size()).append("\n");
+        
+        for (int i = 0; i < slots.size(); i++) {
+            RouletteSlot slot = slots.get(i);
+            info.append("  穴").append(i).append(": ").append(slot.isWinSlot() ? "当たり" : "通常").append("\n");
+        }
+        
+        return info.toString();
+    }
+}

--- a/src/main/java/com/kamesuta/physxmc/widget/JackpotRouletteManager.java
+++ b/src/main/java/com/kamesuta/physxmc/widget/JackpotRouletteManager.java
@@ -1,0 +1,284 @@
+package com.kamesuta.physxmc.widget;
+
+import com.kamesuta.physxmc.PhysxMc;
+import com.kamesuta.physxmc.wrapper.DisplayedPhysxSphere;
+import org.bukkit.Bukkit;
+import org.bukkit.Location;
+import org.bukkit.Material;
+import org.bukkit.entity.Player;
+import org.bukkit.scheduler.BukkitRunnable;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.logging.Logger;
+
+/**
+ * ジャックポットルーレットを管理するクラス
+ */
+public class JackpotRouletteManager {
+    
+    private final List<JackpotRoulette> roulettes = new ArrayList<>();
+    private final Map<UUID, BallTracker> ballTrackers = new HashMap<>(); // ボールの追跡
+    private final Logger logger;
+    
+    // デフォルト設定
+    private static final double DEFAULT_RADIUS = 4.0;
+    private static final double DEFAULT_ROTATION_SPEED = 0.02; // rad/tick
+    private static final Material DEFAULT_DISK_MATERIAL = Material.QUARTZ_BLOCK;
+    private static final Material DEFAULT_WIN_SLOT_MATERIAL = Material.EMERALD_BLOCK;
+    private static final Material DEFAULT_NORMAL_SLOT_MATERIAL = Material.IRON_BLOCK;
+    
+    // ボール追跡時間（秒）
+    private static final int BALL_TRACKING_TIME = 30;
+    
+    public JackpotRouletteManager() {
+        this.logger = Bukkit.getLogger();
+    }
+    
+    /**
+     * 新しいジャックポットルーレットを作成
+     * @param location 中心位置
+     * @param radius 半径
+     * @param rotationSpeed 回転速度
+     * @param diskMaterial 円盤材質
+     * @param winSlotMaterial 当たり穴材質
+     * @param normalSlotMaterial 通常穴材質
+     * @return 作成されたルーレット
+     */
+    public JackpotRoulette createRoulette(Location location, double radius, double rotationSpeed,
+                                         Material diskMaterial, Material winSlotMaterial, Material normalSlotMaterial) {
+        // 重複チェック：3ブロック以内に既存のルーレットがないか確認
+        double minDistance = 6.0; // 半径を考慮した最小距離
+        for (JackpotRoulette existingRoulette : roulettes) {
+            double distance = existingRoulette.getCenterLocation().distance(location);
+            if (distance < minDistance) {
+                logger.warning("ルーレット作成失敗: " + String.format("%.1f", distance) + 
+                             "ブロック先に既存のルーレットがあります（最小距離: " + minDistance + "ブロック）");
+                return null;
+            }
+        }
+        
+        JackpotRoulette roulette = new JackpotRoulette(location, radius, rotationSpeed, 
+                                                      diskMaterial, winSlotMaterial, normalSlotMaterial);
+        roulettes.add(roulette);
+        logger.info("ジャックポットルーレットを作成しました: " + roulettes.size() + "個目");
+        return roulette;
+    }
+    
+    /**
+     * デフォルト設定でルーレットを作成
+     * @param location 中心位置
+     * @return 作成されたルーレット
+     */
+    public JackpotRoulette createDefaultRoulette(Location location) {
+        return createRoulette(location, DEFAULT_RADIUS, DEFAULT_ROTATION_SPEED,
+                            DEFAULT_DISK_MATERIAL, DEFAULT_WIN_SLOT_MATERIAL, DEFAULT_NORMAL_SLOT_MATERIAL);
+    }
+    
+    /**
+     * ボールを投入
+     * @param player プレイヤー
+     * @param location 投入位置（最寄りのルーレットを検索）
+     * @return 投入成功した場合true
+     */
+    public boolean launchBall(Player player, Location location) {
+        // 最寄りのルーレットを検索
+        JackpotRoulette nearestRoulette = findNearestRoulette(location, 10.0);
+        if (nearestRoulette == null) {
+            player.sendMessage("近くにジャックポットルーレットがありません（10ブロック以内）");
+            return false;
+        }
+        
+        // ボールを投入
+        DisplayedPhysxSphere ball = nearestRoulette.launchBall(player);
+        if (ball != null) {
+            // ボール追跡を開始
+            BallTracker tracker = new BallTracker(ball, player, nearestRoulette);
+            ballTrackers.put(java.util.UUID.randomUUID(), tracker);
+            
+            player.sendMessage("🎯 ジャックポットチャレンジ開始！ボールの行方を見守りましょう...");
+            return true;
+        } else {
+            player.sendMessage("ボールの投入に失敗しました");
+            return false;
+        }
+    }
+    
+    /**
+     * 毎tick更新処理
+     */
+    public void update() {
+        // ルーレットの更新
+        Iterator<JackpotRoulette> rouletteIterator = roulettes.iterator();
+        while (rouletteIterator.hasNext()) {
+            JackpotRoulette roulette = rouletteIterator.next();
+            if (roulette.isValid()) {
+                roulette.update();
+            } else {
+                roulette.destroy();
+                rouletteIterator.remove();
+            }
+        }
+        
+        // ボール追跡の更新
+        Iterator<Map.Entry<UUID, BallTracker>> ballIterator = ballTrackers.entrySet().iterator();
+        while (ballIterator.hasNext()) {
+            Map.Entry<UUID, BallTracker> entry = ballIterator.next();
+            BallTracker tracker = entry.getValue();
+            
+            if (tracker.update()) {
+                // 追跡完了（結果確定または時間切れ）
+                ballIterator.remove();
+            }
+        }
+    }
+    
+    /**
+     * 最寄りのルーレットを検索
+     * @param location 基準位置
+     * @param maxDistance 最大距離
+     * @return 最寄りのルーレット、なければnull
+     */
+    public JackpotRoulette findNearestRoulette(Location location, double maxDistance) {
+        JackpotRoulette nearest = null;
+        double nearestDistance = Double.MAX_VALUE;
+        
+        for (JackpotRoulette roulette : roulettes) {
+            double distance = roulette.getCenterLocation().distance(location);
+            if (distance < nearestDistance && distance <= maxDistance) {
+                nearestDistance = distance;
+                nearest = roulette;
+            }
+        }
+        
+        return nearest;
+    }
+    
+    /**
+     * 指定した位置に最も近いルーレットを削除
+     * @param location 基準位置
+     * @param maxDistance 最大距離
+     * @return 削除されたかどうか
+     */
+    public boolean removeNearestRoulette(Location location, double maxDistance) {
+        JackpotRoulette nearest = findNearestRoulette(location, maxDistance);
+        if (nearest != null) {
+            nearest.destroy();
+            roulettes.remove(nearest);
+            logger.info("ジャックポットルーレットを削除しました");
+            return true;
+        }
+        return false;
+    }
+    
+    /**
+     * 全てのルーレットを破壊
+     */
+    public void destroyAll() {
+        for (JackpotRoulette roulette : roulettes) {
+            roulette.destroy();
+        }
+        roulettes.clear();
+        
+        // 追跡中のボールもクリア
+        ballTrackers.clear();
+        
+        logger.info("全てのジャックポットルーレットを破壊しました");
+    }
+    
+    /**
+     * ルーレットの数を取得
+     */
+    public int getRouletteCount() {
+        return roulettes.size();
+    }
+    
+    /**
+     * 追跡中のボール数を取得
+     */
+    public int getTrackingBallCount() {
+        return ballTrackers.size();
+    }
+    
+    /**
+     * ボール追跡クラス
+     */
+    private class BallTracker {
+        private final DisplayedPhysxSphere ball;
+        private final Player player;
+        private final JackpotRoulette roulette;
+        private final long startTime;
+        private boolean resultNotified = false;
+        
+        public BallTracker(DisplayedPhysxSphere ball, Player player, JackpotRoulette roulette) {
+            this.ball = ball;
+            this.player = player;
+            this.roulette = roulette;
+            this.startTime = System.currentTimeMillis();
+        }
+        
+        /**
+         * ボール追跡の更新
+         * @return 追跡完了した場合true
+         */
+        public boolean update() {
+            // ボールが無効になった場合
+            if (ball == null || ball.isDisplayDead()) {
+                if (!resultNotified && player.isOnline()) {
+                    player.sendMessage("🚫 ボールが消失しました。再度お試しください。");
+                }
+                return true; // 追跡終了
+            }
+            
+            // 時間切れチェック
+            long elapsedTime = (System.currentTimeMillis() - startTime) / 1000;
+            if (elapsedTime > BALL_TRACKING_TIME) {
+                if (!resultNotified && player.isOnline()) {
+                    player.sendMessage("⏰ 時間切れです。ボールを回収します。");
+                }
+                PhysxMc.displayedSphereHolder.destroySpecific(ball); // ボールを削除
+                return true; // 追跡終了
+            }
+            
+            // スロット判定
+            if (!resultNotified) {
+                Location ballLocation = ball.getLocation();
+                RouletteSlot slot = roulette.checkBallInSlot(ballLocation);
+                
+                if (slot != null) {
+                    // 結果通知
+                    resultNotified = true;
+                    String resultMessage = slot.getResultMessage(player.getName());
+                    
+                    if (player.isOnline()) {
+                        player.sendMessage(resultMessage);
+                    }
+                    
+                    // 全プレイヤーに通知
+                    Bukkit.broadcastMessage(resultMessage);
+                    
+                    // 少し待ってからボールを削除
+                    new BukkitRunnable() {
+                        @Override
+                        public void run() {
+                            if (ball != null && !ball.isDisplayDead()) {
+                                PhysxMc.displayedSphereHolder.destroySpecific(ball);
+                            }
+                        }
+                    }.runTaskLater(PhysxMc.getPlugin(PhysxMc.class), 60L); // 3秒後
+                    
+                    logger.info("ジャックポット結果: " + player.getName() + " -> スロット" + slot.getSlotId() + 
+                               " (" + (slot.isWinSlot() ? "当たり" : "ハズレ") + ")");
+                    
+                    return true; // 追跡終了
+                }
+            }
+            
+            return false; // 追跡継続
+        }
+    }
+}

--- a/src/main/java/com/kamesuta/physxmc/widget/RouletteSlot.java
+++ b/src/main/java/com/kamesuta/physxmc/widget/RouletteSlot.java
@@ -1,0 +1,149 @@
+package com.kamesuta.physxmc.widget;
+
+import com.kamesuta.physxmc.PhysxMc;
+import com.kamesuta.physxmc.wrapper.DisplayedPhysxBox;
+import lombok.Getter;
+import org.bukkit.Location;
+import org.bukkit.Material;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.util.Vector;
+
+import java.util.List;
+import java.util.logging.Logger;
+
+/**
+ * ジャックポットルーレットの穴（スロット）
+ */
+public class RouletteSlot {
+    
+    @Getter
+    private final int slotId;
+    @Getter
+    private final Location location;
+    @Getter
+    private final Material material;
+    @Getter
+    private final boolean isWinSlot;
+    @Getter
+    private final double angle; // 円盤上の角度
+    
+    private DisplayedPhysxBox slotBox; // スロットの物理オブジェクト
+    private final Logger logger;
+    
+    // スロットのサイズ設定
+    private static final double SLOT_WIDTH = 1.5;
+    private static final double SLOT_DEPTH = 1.0;
+    private static final double SLOT_HEIGHT = 0.5;
+    private static final double DETECTION_RADIUS = 1.2; // ボール検出半径
+    
+    /**
+     * ルーレットスロットを作成
+     * @param slotId スロットID
+     * @param location スロット位置
+     * @param material スロット材質
+     * @param isWinSlot 当たりスロットかどうか
+     * @param angle 円盤上の角度
+     */
+    public RouletteSlot(int slotId, Location location, Material material, boolean isWinSlot, double angle) {
+        this.slotId = slotId;
+        this.location = location.clone();
+        this.material = material;
+        this.isWinSlot = isWinSlot;
+        this.angle = angle;
+        this.logger = PhysxMc.getPlugin(PhysxMc.class).getLogger();
+        
+        createSlot();
+    }
+    
+    /**
+     * スロットの物理オブジェクトを作成
+     */
+    private void createSlot() {
+        Vector slotSize = new Vector(SLOT_WIDTH, SLOT_HEIGHT, SLOT_DEPTH);
+        ItemStack slotItem = new ItemStack(material);
+        List<Vector> offsets = List.of(new Vector()); // 単一のディスプレイ
+        
+        slotBox = PhysxMc.displayedBoxHolder.createDisplayedBox(
+            location.clone(),
+            slotSize,
+            slotItem,
+            offsets,
+            1000.0f, // 重い密度で動かないように
+            false    // プッシャーではない
+        );
+        
+        if (slotBox != null) {
+            slotBox.makeKinematic(true); // キネマティック制御で固定
+            logger.info("スロット" + slotId + "を作成: " + (isWinSlot ? "当たり" : "通常") + 
+                       " at " + String.format("%.1f,%.1f,%.1f", location.getX(), location.getY(), location.getZ()));
+        } else {
+            logger.warning("スロット" + slotId + "の作成に失敗しました");
+        }
+    }
+    
+    /**
+     * 毎tick更新処理
+     */
+    public void update() {
+        // 現在は特に更新処理はなし
+        // 将来的にエフェクトや音声などを追加する可能性
+    }
+    
+    /**
+     * 指定された位置がスロット内にあるかチェック
+     * @param checkLocation チェックする位置
+     * @return スロット内にある場合true
+     */
+    public boolean isLocationInSlot(Location checkLocation) {
+        if (!location.getWorld().equals(checkLocation.getWorld())) {
+            return false;
+        }
+        
+        double distance = location.distance(checkLocation);
+        return distance <= DETECTION_RADIUS && checkLocation.getY() <= location.getY() + SLOT_HEIGHT;
+    }
+    
+    /**
+     * スロットが有効かどうか
+     */
+    public boolean isValid() {
+        return slotBox != null && !slotBox.isDisplayDead();
+    }
+    
+    /**
+     * スロットを破壊
+     */
+    public void destroy() {
+        if (slotBox != null) {
+            PhysxMc.displayedBoxHolder.destroySpecific(slotBox);
+            slotBox = null;
+        }
+        logger.info("スロット" + slotId + "を破壊しました");
+    }
+    
+    /**
+     * 結果メッセージを取得
+     * @param playerName プレイヤー名
+     * @return 結果メッセージ
+     */
+    public String getResultMessage(String playerName) {
+        if (isWinSlot) {
+            return "🎉 " + playerName + "さんが当たり穴" + slotId + "に入りました！ジャックポット獲得！";
+        } else {
+            return "💔 " + playerName + "さんは穴" + slotId + "に入りました。残念！";
+        }
+    }
+    
+    /**
+     * スロット情報を取得
+     */
+    public String getSlotInfo() {
+        return String.format("スロット%d: %s (%.1f,%.1f,%.1f) 角度%.1f°", 
+                           slotId, 
+                           isWinSlot ? "当たり" : "通常",
+                           location.getX(), 
+                           location.getY(), 
+                           location.getZ(),
+                           Math.toDegrees(angle));
+    }
+}


### PR DESCRIPTION
## Summary
- メダルゲームのジャックポットチャンス機能を実装
- 回転する円盤でボールを転がして穴に落とす物理抽選システム
- 5つの穴（1つの当たり穴と4つの通常穴）による本格的な抽選機能

## 主要機能

### 1. JackpotRoulette（回転ルーレット）
- キネマティック制御による常時回転する円盤
- 円盤周囲に等間隔で配置された5つのスロット
- 物理演算による自然なボールの動き

### 2. JackpotRouletteManager（ルーレット管理）
- 複数ルーレットの同時管理
- ボール追跡システム（30秒間の自動追跡）
- 結果判定とプレイヤー通知機能

### 3. RouletteSlot（スロット判定）
- 当たり穴とハズレ穴の区別
- ボール落下判定システム
- 結果メッセージの自動生成

### 4. コマンドインターフェース
- `/physxmc jackpot create` - ルーレット作成
- `/physxmc jackpot launch` - ボール投入
- `/physxmc jackpot remove` - ルーレット削除
- `/physxmc jackpot clear` - 全削除
- `/physxmc jackpot count` - 状況確認
- `/physxmc jackpot info` - 詳細情報

## 技術的特徴

### 物理演算の活用
- 回転円盤のキネマティック制御
- ボールの重力落下と衝突判定
- リアルなランダム性を実現する物理挙動

### メモリ管理
- DisplayedBoxHolder/SphereHolderを使用した適切なオブジェクト削除
- 自動クリーンアップによるメモリリーク防止

### ユーザビリティ
- 全プレイヤーへの結果ブロードキャスト
- 直感的なコマンド操作
- 適切なエラーハンドリング

## Test plan
- [x] ビルドが正常に完了することを確認
- [x] ルーレット作成・削除機能の動作確認
- [x] ボール投入と追跡システムの動作確認
- [x] 結果判定とメッセージ表示の動作確認
- [ ] 複数ルーレットの同時運用テスト
- [ ] 長時間運用でのメモリリークテスト
- [ ] サーバー再起動後の動作確認

## 使用方法例

```bash
# ルーレット作成
/physxmc jackpot create

# ボール投入（ゲーム開始）
/physxmc jackpot launch

# 状況確認
/physxmc jackpot count

# ルーレット削除
/physxmc jackpot remove
```

🎮 本格的なメダルゲームのジャックポットチャンスが実現できます！

🤖 Generated with [Claude Code](https://claude.ai/code)