### PR TITLE
summonコマンドにブロックタイプ指定機能を追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ PhysxMcは、MinecraftのPaperサーバー向けの物理エンジンプラグ�
 +/physxmc debugmode
 +/physxmc density <float>             # 例: /physxmc density 1.5
 +/physxmc updatecurrentchunk
-+/physxmc summon <x> <y> <z>          # 例: /physxmc summon 2 2 2
++/physxmc summon <x> <y> <z> [ブロック名] # 例: /physxmc summon 2 2 2 DIAMOND_BLOCK
 +/physxmc gravity <x> <y> <z>         # 例: /physxmc gravity 0 -19.62 0
 
 # コインシステム
@@ -128,9 +128,11 @@ PhysxMcは、MinecraftのPaperサーバー向けの物理エンジンプラグ�
 - **機能**: プレイヤーの現在位置のチャンク地形をリロード
 - **用途**: 手動での地形更新
 
-#### `/physxmc summon <x> <y> <z>`
-- **機能**: 指定サイズのテスト物理オブジェクトを生成
+#### `/physxmc summon <x> <y> <z> [ブロック名]`
+- **機能**: 指定サイズの物理演算ブロックを生成
 - **パラメータ**: x, y, z（ブロック単位のサイズ）
+- **ブロック名**: 生成するブロックの種類（省略時はコマンドブロック）
+- **例**: `/physxmc summon 2 2 2 DIAMOND_BLOCK`
 
 #### `/physxmc gravity <x> <y> <z>`
 - **機能**: 重力ベクトルの設定

--- a/src/main/java/com/kamesuta/physxmc/command/PhysxCommand.java
+++ b/src/main/java/com/kamesuta/physxmc/command/PhysxCommand.java
@@ -89,8 +89,20 @@ public class PhysxCommand extends CommandBase implements Listener {
                 sendUsage(sender);
                 return true;
             }
-            PhysxMc.displayedBoxHolder.createDisplayedBox(((Player) sender).getLocation(), new Vector(x, y, z), new ItemStack(Material.COMMAND_BLOCK), List.of(new Vector()));
-            sender.sendMessage("テストブロックを生成しました");
+            
+            // ブロックタイプを指定できるようにする（オプション）
+            Material blockType = Material.COMMAND_BLOCK; // デフォルトはコマンドブロック
+            if (arguments.length > 4 && arguments[4] != null) {
+                try {
+                    blockType = Material.valueOf(arguments[4].toUpperCase());
+                } catch (IllegalArgumentException e) {
+                    sender.sendMessage("無効なブロック名です: " + arguments[4]);
+                    return true;
+                }
+            }
+            
+            PhysxMc.displayedBoxHolder.createDisplayedBox(((Player) sender).getLocation(), new Vector(x, y, z), new ItemStack(blockType), List.of(new Vector()));
+            sender.sendMessage("物理演算ブロックを生成しました (サイズ:" + x + "x" + y + "x" + z + ", ブロック:" + blockType + ")");
             return true;
         } else if (arguments[0].equals(gravityArgument) && arguments[1] != null && arguments[2] != null && arguments[3] != null) {
             float x, y, z;
@@ -293,7 +305,7 @@ public class PhysxCommand extends CommandBase implements Listener {
                 "/physxmc debugmode: 右クリックで持っているアイテムが投げられたり掴めたりするデバッグモードを有効/無効にする\n" +
                 "/physxmc density {float型}: 召喚する物理オブジェクトの既定の密度を設定する\n" +
                 "/physxmc updateCurrentChunk: プレイヤーが今いるチャンクの地形をリロードする\n" +
-                "/physxmc summon {縦}　{高さ}　{横}: テストオブジェクトを1個召喚する\n" +
+                "/physxmc summon {縦}　{高さ}　{横} [ブロック名]: 物理演算ブロックを召喚する\n" +
                 "/physxmc gravity {x}　{y}　{z}: 重力の大きさを設定する\n" +
                 "/physxmc coin enable: 鉄製のトラップドアを使ったコイン投擲システムを有効/無効にする\n" +
                 "/physxmc pusher create {高さ} {幅} {長さ} {移動範囲} [ブロック名] [速度]: 指定サイズのプッシャーを作成する\n" +


### PR DESCRIPTION
## Summary
- 既存のsummonコマンドにオプションでブロックタイプを指定できる機能を追加
- 使用例: `/physxmc summon 2 2 2 DIAMOND_BLOCK`
- デフォルトはコマンドブロック（既存の動作を維持）
- 不正なブロック名の場合はエラーメッセージを表示

## Test plan
- [ ] コマンドがブロックタイプなしで動作することを確認
- [ ] コマンドがブロックタイプありで動作することを確認
- [ ] 不正なブロック名でエラーメッセージが表示されることを確認
- [ ] 生成されたブロックが指定したタイプで表示されることを確認
- [ ] 生成されたブロックが物理演算されることを確認

🤖 Generated with [Claude Code](https://claude.ai/code)