### PR TITLE
rampコマンドクラッシュ問題のデバッグ強化

### DIFF
--- a/src/main/java/com/kamesuta/physxmc/command/PhysxCommand.java
+++ b/src/main/java/com/kamesuta/physxmc/command/PhysxCommand.java
@@ -251,11 +251,24 @@ public class PhysxCommand extends CommandBase implements Listener {
             if (arguments[1].equals("create") && arguments.length >= 6 && 
                 arguments[2] != null && arguments[3] != null && arguments[4] != null && arguments[5] != null) {
                 // /physxmc ramp create <pitch> <width> <length> <thickness> [material]
+                
+                // デバッグログ: 受け取った引数を出力
+                sender.sendMessage("DEBUG: 受け取った引数:");
+                for (int i = 0; i < arguments.length; i++) {
+                    sender.sendMessage("  arguments[" + i + "] = '" + arguments[i] + "'");
+                }
+                
                 try {
                     double pitch = Double.parseDouble(arguments[2]);
                     double width = Double.parseDouble(arguments[3]);
                     double length = Double.parseDouble(arguments[4]);
                     double thickness = Double.parseDouble(arguments[5]);
+
+                    sender.sendMessage("DEBUG: パース後の数値:");
+                    sender.sendMessage("  pitch = " + pitch);
+                    sender.sendMessage("  width = " + width);
+                    sender.sendMessage("  length = " + length);
+                    sender.sendMessage("  thickness = " + thickness);
 
                     if (width <= 0 || length <= 0 || thickness <= 0) {
                         sender.sendMessage("幅、長さ、厚みは正の値である必要があります");
@@ -271,12 +284,16 @@ public class PhysxCommand extends CommandBase implements Listener {
                     if (arguments.length > 6 && arguments[6] != null && !arguments[6].trim().isEmpty()) {
                         try {
                             material = Material.valueOf(arguments[6].toUpperCase());
+                            sender.sendMessage("DEBUG: マテリアル = " + material);
                         } catch (IllegalArgumentException e) {
                             sender.sendMessage("無効なブロック名です: " + arguments[6]);
                             return true;
                         }
+                    } else {
+                        sender.sendMessage("DEBUG: デフォルトマテリアル使用 = " + material);
                     }
 
+                    sender.sendMessage("DEBUG: ランプ作成を開始します...");
                     DisplayedPhysxBox ramp = PhysxMc.rampManager.createRamp(player.getLocation(), pitch, width, length, thickness, material);
                     if (ramp != null) {
                         sender.sendMessage("ランプを作成しました (角度:" + pitch + ", 幅:" + width + ", 長さ:" + length + ", 厚み:" + thickness + ", ブロック:" + material + ")");
@@ -286,7 +303,7 @@ public class PhysxCommand extends CommandBase implements Listener {
                     return true;
 
                 } catch (NumberFormatException e) {
-                    sender.sendMessage("数値が正しくありません");
+                    sender.sendMessage("数値が正しくありません: " + e.getMessage());
                     return true;
                 }
             } else if (arguments.length >= 2 && arguments[1].equals("remove")) {

--- a/src/main/java/com/kamesuta/physxmc/widget/RampManager.java
+++ b/src/main/java/com/kamesuta/physxmc/widget/RampManager.java
@@ -88,7 +88,11 @@ public class RampManager {
                 return null;
             }
             
-            // 少し待ってからキネマティック設定（PhysXが安定してから）
+            // キネマティック設定を無効化してテスト（クラッシュ原因の特定）
+            logger.info("キネマティック設定をスキップしてテスト中...");
+            
+            // 遅延キネマティック設定をコメントアウト
+            /*
             org.bukkit.scheduler.BukkitRunnable kinematicTask = new org.bukkit.scheduler.BukkitRunnable() {
                 @Override
                 public void run() {
@@ -109,6 +113,7 @@ public class RampManager {
             
             // 1tick後に実行（PhysXの初期化を待つ）
             kinematicTask.runTaskLater(com.kamesuta.physxmc.PhysxMc.getPlugin(com.kamesuta.physxmc.PhysxMc.class), 1L);
+            */
             
             ramps.add(ramp);
             

--- a/src/main/java/com/kamesuta/physxmc/wrapper/DisplayedBoxHolder.java
+++ b/src/main/java/com/kamesuta/physxmc/wrapper/DisplayedBoxHolder.java
@@ -119,6 +119,8 @@ public class DisplayedBoxHolder {
             float yaw = location.getYaw();
             float pitch = location.getPitch();
             
+            org.bukkit.Bukkit.getLogger().info("デバッグ: 元の角度 - yaw=" + yaw + ", pitch=" + pitch);
+            
             // NaNやInfinityのチェック
             if (Float.isNaN(yaw) || Float.isInfinite(yaw)) yaw = 0;
             if (Float.isNaN(pitch) || Float.isInfinite(pitch)) pitch = 0;
@@ -128,12 +130,16 @@ public class DisplayedBoxHolder {
             while (yaw < -180) yaw += 360;
             pitch = Math.max(-90, Math.min(90, pitch));
             
+            org.bukkit.Bukkit.getLogger().info("デバッグ: 正規化後の角度 - yaw=" + yaw + ", pitch=" + pitch);
+            
             Quaternionf quat = new Quaternionf()
                     .rotateY((float) -Math.toRadians(yaw))
                     .rotateX((float) Math.toRadians(pitch));
                     
             // クォータニオンの正規化
             quat.normalize();
+            
+            org.bukkit.Bukkit.getLogger().info("デバッグ: クォータニオン - x=" + quat.x + ", y=" + quat.y + ", z=" + quat.z + ", w=" + quat.w);
             
             Map<BlockDisplay[], Vector> displayMap = new HashMap<>();
             Map<PxBoxGeometry, PxVec3> boxGeometries = new HashMap<>();

--- a/src/main/java/com/kamesuta/physxmc/wrapper/IntegratedPhysxWorld.java
+++ b/src/main/java/com/kamesuta/physxmc/wrapper/IntegratedPhysxWorld.java
@@ -124,6 +124,8 @@ public class IntegratedPhysxWorld extends PhysxWorld {
      */
     public DisplayedPhysxBox addBox(BoxData data, Map<BlockDisplay[], Vector> display, boolean isCoin, boolean isPusher) {
         try {
+            org.bukkit.Bukkit.getLogger().info("デバッグ: DisplayedPhysxBox作成開始");
+            
             DisplayedPhysxBox box = new DisplayedPhysxBox(physics, data, display, isCoin, isPusher);
             
             if (box == null) {
@@ -131,18 +133,27 @@ public class IntegratedPhysxWorld extends PhysxWorld {
                 return null;
             }
             
+            org.bukkit.Bukkit.getLogger().info("デバッグ: DisplayedPhysxBoxコンストラクタ成功");
+            
             if (box.getActor() == null) {
                 org.bukkit.Bukkit.getLogger().severe("DisplayedPhysxBox作成失敗: アクターがnullです");
                 return null;
             }
+            
+            org.bukkit.Bukkit.getLogger().info("デバッグ: アクター検証成功");
             
             if (scene == null) {
                 org.bukkit.Bukkit.getLogger().severe("DisplayedPhysxBox作成失敗: PhysXシーンがnullです");
                 return null;
             }
             
+            org.bukkit.Bukkit.getLogger().info("デバッグ: シーンにアクター追加中...");
+            
             scene.addActor(box.getActor());
             org.bukkit.Bukkit.getLogger().info("DisplayedPhysxBoxをシーンに追加しました");
+            
+            org.bukkit.Bukkit.getLogger().info("デバッグ: シーン追加完了、正常に終了中...");
+            
             return box;
         } catch (Exception e) {
             org.bukkit.Bukkit.getLogger().severe("DisplayedPhysxBox作成中にエラーが発生しました: " + e.getMessage());


### PR DESCRIPTION
## Summary
- rampコマンド実行時のクラッシュ（0xC0000374）原因特定のためのデバッグ強化
- キネマティック設定を一時的に無効化してクラッシュ原因を切り分け
- 詳細なログ出力で問題発生箇所を特定

## 背景
`/physxmc ramp create 20 3 6 0.5 QUARTZ_BLOCK`実行時に以下の流れでクラッシュが発生：
1. コマンド認識成功 ✓
2. "DisplayedPhysxBoxをシーンに追加しました" ✓  
3. その直後にクラッシュ（0xC0000374 - ヒープ破損）

## 主な変更
- **RampManager.java**: キネマティック設定を一時的にコメントアウト
- **PhysxCommand.java**: 引数パースとパラメータ値の詳細ログ追加
- **DisplayedBoxHolder.java**: 角度正規化とクォータニオン生成の詳細ログ
- **IntegratedPhysxWorld.java**: オブジェクト作成各段階の詳細ログ

## 期待する結果
### キネマティック設定が原因の場合
- クラッシュが発生しない
- ランプが動的オブジェクトとして正常作成される

### DisplayedPhysxBox作成が原因の場合  
- 依然としてクラッシュが発生
- ログから具体的な問題箇所を特定可能

## Test plan
- [x] デバッグログの実装
- [x] キネマティック設定の無効化
- [ ] `/physxmc ramp create 20 3 6 0.5 QUARTZ_BLOCK`でのテスト実行
- [ ] ログ分析による根本原因の特定
- [ ] 特定された原因に基づく最終修正

🤖 Generated with [Claude Code](https://claude.ai/code)